### PR TITLE
Implement Flutter API Explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# rapid-api-explorer
+# Rapid API Explorer
+
+Un cliente de APIs REST/GraphQL construido con Flutter.
+
+Este proyecto es un ejemplo mínimo de un "Postman" en Flutter que utiliza Riverpod, Hive y Dio.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import 'models/request_model.dart';
+import 'screens/collections_screen.dart';
+import 'screens/environments_screen.dart';
+import 'screens/home_screen.dart';
+import 'screens/request_editor_screen.dart';
+import 'storage/hive_storage.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await HiveStorage.init();
+
+  // Add sample data if boxes are empty
+  final reqBox = Hive.box<RequestModel>('requests');
+  if (reqBox.isEmpty) {
+    reqBox.put(
+      'sample',
+      RequestModel(
+        id: 'sample',
+        name: 'Todo example',
+        url: 'https://jsonplaceholder.typicode.com/todos/1',
+        method: 'GET',
+      ),
+    );
+  }
+
+  runApp(const ProviderScope(child: MyApp()));
+}
+
+class MyApp extends ConsumerWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => const HomeScreen(),
+        ),
+        GoRoute(
+          path: '/request',
+          builder: (context, state) {
+            final req = state.extra as RequestModel?;
+            return RequestEditorScreen(request: req);
+          },
+        ),
+        GoRoute(
+          path: '/environments',
+          builder: (context, state) => const EnvironmentsScreen(),
+        ),
+        GoRoute(
+          path: '/collections',
+          builder: (context, state) => const CollectionsScreen(),
+        ),
+      ],
+    );
+
+    return MaterialApp.router(
+      title: 'Rapid API Explorer',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      routerConfig: router,
+    );
+  }
+}

--- a/lib/models/environment_model.dart
+++ b/lib/models/environment_model.dart
@@ -1,0 +1,21 @@
+import 'package:hive/hive.dart';
+
+part 'environment_model.g.dart';
+
+@HiveType(typeId: 1)
+class EnvironmentModel extends HiveObject {
+  @HiveField(0)
+  String id;
+
+  @HiveField(1)
+  String name;
+
+  @HiveField(2)
+  Map<String, String> variables;
+
+  EnvironmentModel({
+    required this.id,
+    required this.name,
+    Map<String, String>? variables,
+  }) : variables = variables ?? {};
+}

--- a/lib/models/environment_model.g.dart
+++ b/lib/models/environment_model.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - MANUAL ADAPTER
+
+import 'package:hive/hive.dart';
+import 'environment_model.dart';
+
+class EnvironmentModelAdapter extends TypeAdapter<EnvironmentModel> {
+  @override
+  final int typeId = 1;
+
+  @override
+  EnvironmentModel read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{};
+    for (int i = 0; i < numOfFields; i++) {
+      fields[reader.readByte()] = reader.read();
+    }
+    return EnvironmentModel(
+      id: fields[0] as String,
+      name: fields[1] as String,
+      variables: (fields[2] as Map?)?.cast<String, String>(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, EnvironmentModel obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.name)
+      ..writeByte(2)
+      ..write(obj.variables);
+  }
+}

--- a/lib/models/request_model.dart
+++ b/lib/models/request_model.dart
@@ -1,0 +1,33 @@
+import 'package:hive/hive.dart';
+
+part 'request_model.g.dart';
+
+@HiveType(typeId: 0)
+class RequestModel extends HiveObject {
+  @HiveField(0)
+  String id;
+
+  @HiveField(1)
+  String name;
+
+  @HiveField(2)
+  String url;
+
+  @HiveField(3)
+  String method;
+
+  @HiveField(4)
+  Map<String, String> headers;
+
+  @HiveField(5)
+  String body;
+
+  RequestModel({
+    required this.id,
+    required this.name,
+    required this.url,
+    required this.method,
+    Map<String, String>? headers,
+    this.body = '',
+  }) : headers = headers ?? {};
+}

--- a/lib/models/request_model.g.dart
+++ b/lib/models/request_model.g.dart
@@ -1,0 +1,44 @@
+// GENERATED CODE - MANUAL ADAPTER
+
+import 'package:hive/hive.dart';
+import 'request_model.dart';
+
+class RequestModelAdapter extends TypeAdapter<RequestModel> {
+  @override
+  final int typeId = 0;
+
+  @override
+  RequestModel read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{};
+    for (int i = 0; i < numOfFields; i++) {
+      fields[reader.readByte()] = reader.read();
+    }
+    return RequestModel(
+      id: fields[0] as String,
+      name: fields[1] as String,
+      url: fields[2] as String,
+      method: fields[3] as String,
+      headers: (fields[4] as Map?)?.cast<String, String>(),
+      body: fields[5] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, RequestModel obj) {
+    writer
+      ..writeByte(6)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.name)
+      ..writeByte(2)
+      ..write(obj.url)
+      ..writeByte(3)
+      ..write(obj.method)
+      ..writeByte(4)
+      ..write(obj.headers)
+      ..writeByte(5)
+      ..write(obj.body);
+  }
+}

--- a/lib/providers/environment_providers.dart
+++ b/lib/providers/environment_providers.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+import '../models/environment_model.dart';
+
+final environmentsBoxProvider = Provider<Box<EnvironmentModel>>((ref) {
+  return Hive.box<EnvironmentModel>('environments');
+});
+
+class EnvironmentListNotifier extends StateNotifier<List<EnvironmentModel>> {
+  final Box<EnvironmentModel> box;
+  EnvironmentListNotifier(this.box) : super(box.values.toList());
+
+  void add(EnvironmentModel env) {
+    box.put(env.id, env);
+    state = box.values.toList();
+  }
+
+  void remove(String id) {
+    box.delete(id);
+    state = box.values.toList();
+  }
+
+  void updateEnv(EnvironmentModel env) {
+    box.put(env.id, env);
+    state = box.values.toList();
+  }
+}
+
+final environmentListProvider =
+    StateNotifierProvider<EnvironmentListNotifier, List<EnvironmentModel>>((ref) {
+  final box = ref.watch(environmentsBoxProvider);
+  return EnvironmentListNotifier(box);
+});
+
+final activeEnvironmentProvider =
+    StateProvider<EnvironmentModel?>((ref) => null);

--- a/lib/providers/request_providers.dart
+++ b/lib/providers/request_providers.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+import '../models/request_model.dart';
+
+final requestsBoxProvider = Provider<Box<RequestModel>>((ref) {
+  return Hive.box<RequestModel>('requests');
+});
+
+class RequestListNotifier extends StateNotifier<List<RequestModel>> {
+  final Box<RequestModel> box;
+  RequestListNotifier(this.box) : super(box.values.toList());
+
+  void add(RequestModel req) {
+    box.put(req.id, req);
+    state = box.values.toList();
+  }
+
+  void remove(String id) {
+    box.delete(id);
+    state = box.values.toList();
+  }
+
+  void updateReq(RequestModel req) {
+    box.put(req.id, req);
+    state = box.values.toList();
+  }
+}
+
+final requestListProvider =
+    StateNotifierProvider<RequestListNotifier, List<RequestModel>>((ref) {
+  final box = ref.watch(requestsBoxProvider);
+  return RequestListNotifier(box);
+});

--- a/lib/screens/collections_screen.dart
+++ b/lib/screens/collections_screen.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../models/request_model.dart';
+import '../providers/request_providers.dart';
+
+class CollectionsScreen extends ConsumerWidget {
+  const CollectionsScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final requests = ref.watch(requestListProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Colecciones')),
+      body: ListView(
+        children: requests
+            .map((r) => ListTile(
+                  title: Text(r.name),
+                  subtitle: Text('${r.method} ${r.url}'),
+                  onTap: () {
+                    context.push('/request', extra: r);
+                  },
+                  trailing: IconButton(
+                    icon: const Icon(Icons.delete),
+                    onPressed: () {
+                      ref.read(requestListProvider.notifier).remove(r.id);
+                    },
+                  ),
+                ))
+            .toList(),
+      ),
+    );
+  }
+}

--- a/lib/screens/environments_screen.dart
+++ b/lib/screens/environments_screen.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/environment_model.dart';
+import '../providers/environment_providers.dart';
+
+class EnvironmentsScreen extends ConsumerStatefulWidget {
+  const EnvironmentsScreen({Key? key}) : super(key: key);
+
+  @override
+  ConsumerState<EnvironmentsScreen> createState() => _EnvironmentsScreenState();
+}
+
+class _EnvironmentsScreenState extends ConsumerState<EnvironmentsScreen> {
+  final _nameController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    final envs = ref.watch(environmentListProvider);
+    final activeEnv = ref.watch(activeEnvironmentProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Entornos')),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Nombre del entorno'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                final env = EnvironmentModel(id: const Uuid().v4(), name: _nameController.text);
+                ref.read(environmentListProvider.notifier).add(env);
+                _nameController.clear();
+              },
+              child: const Text('Agregar'),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: ListView(
+                children: envs.map((e) => ListTile(
+                      title: Text(e.name),
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (activeEnv?.id == e.id) const Icon(Icons.check),
+                          IconButton(
+                            icon: const Icon(Icons.delete),
+                            onPressed: () {
+                              ref.read(environmentListProvider.notifier).remove(e.id);
+                            },
+                          ),
+                        ],
+                      ),
+                      onTap: () {
+                        ref.read(activeEnvironmentProvider.notifier).state = e;
+                      },
+                    )).toList(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../providers/environment_providers.dart';
+
+class HomeScreen extends ConsumerWidget {
+  const HomeScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final activeEnv = ref.watch(activeEnvironmentProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Rapid API Explorer'),
+        actions: [
+          if (activeEnv != null) Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0),
+            child: Center(child: Text(activeEnv.name)),
+          ),
+        ],
+      ),
+      drawer: Drawer(
+        child: ListView(
+          children: [
+            DrawerHeader(child: Text('Menu')),
+            ListTile(
+              title: Text('Colecciones'),
+              onTap: () => context.push('/collections'),
+            ),
+            ListTile(
+              title: Text('Entornos'),
+              onTap: () => context.push('/environments'),
+            ),
+            ListTile(
+              title: Text('Nuevo Request'),
+              onTap: () => context.push('/request'),
+            ),
+          ],
+        ),
+      ),
+      body: const Center(child: Text('Selecciona o crea una petición')),    );
+  }
+}

--- a/lib/screens/request_editor_screen.dart
+++ b/lib/screens/request_editor_screen.dart
@@ -1,0 +1,185 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import 'package:flutter_highlight/flutter_highlight.dart';
+import '../models/request_model.dart';
+import '../providers/request_providers.dart';
+import '../services/http_service.dart';
+
+class RequestEditorScreen extends ConsumerStatefulWidget {
+  final RequestModel? request;
+  const RequestEditorScreen({Key? key, this.request}) : super(key: key);
+
+  @override
+  ConsumerState<RequestEditorScreen> createState() => _RequestEditorScreenState();
+}
+
+class _RequestEditorScreenState extends ConsumerState<RequestEditorScreen> {
+  final _urlController = TextEditingController();
+  final _bodyController = TextEditingController();
+  String _method = 'GET';
+  final List<MapEntry<TextEditingController, TextEditingController>> _headers = [];
+
+  Response<dynamic>? _response;
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.request != null) {
+      final r = widget.request!;
+      _urlController.text = r.url;
+      _bodyController.text = r.body;
+      _method = r.method;
+      r.headers.forEach((key, value) {
+        _headers.add(MapEntry(TextEditingController(text: key), TextEditingController(text: value)));
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _urlController.dispose();
+    _bodyController.dispose();
+    for (var pair in _headers) {
+      pair.key.dispose();
+      pair.value.dispose();
+    }
+    super.dispose();
+  }
+
+  void _send() async {
+    setState(() { _loading = true; });
+    final http = ref.read(httpServiceProvider);
+    final headers = {for (var pair in _headers) pair.key.text: pair.value.text};
+    final options = RequestOptions(
+      path: _urlController.text,
+      method: _method,
+      headers: headers,
+      data: _bodyController.text.isNotEmpty ? _bodyController.text : null,
+    );
+    try {
+      final resp = await http.sendRequest(options);
+      setState(() => _response = resp);
+    } catch (e) {
+      setState(() => _response = Response(requestOptions: options, statusCode: 500, statusMessage: e.toString()));
+    } finally {
+      setState(() { _loading = false; });
+    }
+  }
+
+  void _saveRequest() {
+    final id = widget.request?.id ?? const Uuid().v4();
+    final req = RequestModel(
+      id: id,
+      name: widget.request?.name ?? 'Request $id',
+      url: _urlController.text,
+      method: _method,
+      headers: {for (var pair in _headers) pair.key.text: pair.value.text},
+      body: _bodyController.text,
+    );
+    if (widget.request == null) {
+      ref.read(requestListProvider.notifier).add(req);
+    } else {
+      ref.read(requestListProvider.notifier).updateReq(req);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.request?.name ?? 'Nuevo Request'),
+        actions: [
+          IconButton(onPressed: _saveRequest, icon: Icon(Icons.save)),
+        ],
+      ),
+      body: Row(
+        children: [
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.all(8),
+              children: [
+                TextField(
+                  controller: _urlController,
+                  decoration: const InputDecoration(labelText: 'URL'),
+                ),
+                DropdownButton<String>(
+                  value: _method,
+                  items: ['GET','POST','PUT','DELETE','PATCH']
+                      .map((m) => DropdownMenuItem(value: m, child: Text(m)))
+                      .toList(),
+                  onChanged: (v) => setState(() => _method = v!),
+                ),
+                const SizedBox(height: 8),
+                Text('Headers'),
+                Column(
+                  children: [
+                    for (var pair in _headers)
+                      Row(
+                        children: [
+                          Expanded(child: TextField(controller: pair.key, decoration: const InputDecoration(hintText: 'Key'))),
+                          const SizedBox(width: 8),
+                          Expanded(child: TextField(controller: pair.value, decoration: const InputDecoration(hintText: 'Value'))),
+                          IconButton(icon: const Icon(Icons.delete), onPressed: () { setState(() { _headers.remove(pair); }); }),
+                        ],
+                      ),
+                    TextButton(
+                      onPressed: () {
+                        setState(() { _headers.add(MapEntry(TextEditingController(), TextEditingController())); });
+                      },
+                      child: const Text('Agregar Header'),
+                    ),
+                  ],
+                ),
+                TextField(
+                  controller: _bodyController,
+                  decoration: const InputDecoration(labelText: 'Body (JSON)'),
+                  maxLines: 5,
+                ),
+                const SizedBox(height: 8),
+                ElevatedButton(
+                  onPressed: _loading ? null : _send,
+                  child: const Text('Enviar'),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: _response == null ? const Center(child: Text('Sin respuesta')) : _buildResponse(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildResponse() {
+    final resp = _response!;
+    final headers = resp.headers.map.map((k, v) => MapEntry(k, v.join(',')));
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Status: ${resp.statusCode}'),
+          const SizedBox(height: 4),
+          Text('Headers:'),
+          for (var entry in headers.entries) Text('${entry.key}: ${entry.value}'),
+          const Divider(),
+          const Text('Body:'),
+          Container(
+            color: Colors.grey[200],
+            width: double.infinity,
+            child: HighlightView(
+              resp.data.toString(),
+              language: 'json',
+              padding: const EdgeInsets.all(8),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/http_service.dart
+++ b/lib/services/http_service.dart
@@ -1,0 +1,43 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/environment_model.dart';
+import '../providers/environment_providers.dart';
+
+final httpServiceProvider = Provider<HttpService>((ref) {
+  return HttpService(ref);
+});
+
+class HttpService {
+  final Ref ref;
+  final Dio dio = Dio();
+
+  HttpService(this.ref) {
+    dio.interceptors.add(InterceptorsWrapper(onRequest: (options, handler) {
+      final env = ref.read(activeEnvironmentProvider).maybeWhen(
+            data: (env) => env,
+            orElse: () => null,
+          );
+      if (env != null) {
+        options.path = _interpolate(options.path, env.variables);
+        options.headers = options.headers.map((k, v) => MapEntry(k, _interpolate('$v', env.variables)));
+        if (options.data is String) {
+          options.data = _interpolate(options.data, env.variables);
+        }
+      }
+      handler.next(options);
+    }));
+  }
+
+  Future<Response> sendRequest(RequestOptions options) {
+    return dio.fetch(options);
+  }
+
+  String _interpolate(String input, Map<String, String> vars) {
+    var result = input;
+    vars.forEach((key, value) {
+      result = result.replaceAll('{{$key}}', value);
+    });
+    return result;
+  }
+}

--- a/lib/storage/hive_storage.dart
+++ b/lib/storage/hive_storage.dart
@@ -1,0 +1,15 @@
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../models/environment_model.dart';
+import '../models/request_model.dart';
+
+class HiveStorage {
+  static Future<void> init() async {
+    await Hive.initFlutter();
+    Hive.registerAdapter(RequestModelAdapter());
+    Hive.registerAdapter(EnvironmentModelAdapter());
+
+    await Hive.openBox<RequestModel>('requests');
+    await Hive.openBox<EnvironmentModel>('environments');
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,26 @@
+name: rapid_api_explorer
+description: A Postman-like REST/GraphQL client built with Flutter.
+version: 0.1.0
+publish_to: 'none'
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+  dio: ^5.3.2
+  flutter_riverpod: ^2.3.6
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
+  flutter_highlight: ^0.8.2
+  go_router: ^6.5.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- set up Flutter project skeleton with dependencies
- implement models with Hive adapters
- add Riverpod providers and HTTP service
- create basic screens for requests, environments, and collections
- initialize Hive and sample request in main

## Testing
- `dart format lib` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6856388606c88329aa77b23d53ed1443