### PR TITLE
Update Dart SDK requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 Un cliente de APIs REST/GraphQL construido con Flutter.
 
 Este proyecto es un ejemplo mínimo de un "Postman" en Flutter que utiliza Riverpod, Hive y Dio.
+
+Requiere Flutter >=3.7.0 para ejecutarse correctamente.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=3.7.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- upgrade Dart SDK version to support Flutter 3.29
- document minimum Flutter version

## Testing
- `dart pub get` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68563b2de3d483298873f8af0d9eabbd